### PR TITLE
Add category pages, shared ToolCategoryPage, and dynamic sitemap

### DIFF
--- a/src/app/dev-tools/page.tsx
+++ b/src/app/dev-tools/page.tsx
@@ -1,0 +1,46 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Developer Tools - Free Online Dev Utilities",
+  description:
+    "Use free browser-based developer tools including JSON Formatter, Base64 Encoder, JWT Decoder, Regex Tester, API Client, UUID Generator, and more.",
+  keywords: [
+    "developer tools online",
+    "free dev tools",
+    "json formatter",
+    "base64 encoder",
+    "jwt decoder",
+    "regex tester",
+    "api client",
+    "uuid generator",
+  ],
+  alternates: {
+    canonical: "/dev-tools",
+  },
+  openGraph: {
+    title: "Developer Tools - Free Online Dev Utilities",
+    description:
+      "17 privacy-first developer tools that run in your browser. No sign-up and no file uploads required.",
+    type: "website",
+    url: "https://utilbyte.app/dev-tools",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Developer Tools - UtilByte",
+    description:
+      "Free browser-based dev utilities for JSON, Base64, JWT, Regex, SQL, and API workflows.",
+  },
+};
+
+export default function DevToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="Dev"
+      badgeLabel="Developer Tools"
+      heading="All Developer Tools"
+      description="Utilities built for daily developer workflows. Everything runs client-side for speed and privacy."
+      accentClassName="border-amber-500/30 bg-amber-500/10 text-amber-400"
+    />
+  );
+}

--- a/src/app/image-tools/page.tsx
+++ b/src/app/image-tools/page.tsx
@@ -1,0 +1,21 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Image Tools - Compress, Resize, Convert & Edit Images",
+  description:
+    "Free image tools to compress, resize, convert, blur, crop, remove backgrounds, and extract text from images directly in your browser.",
+  alternates: { canonical: "/image-tools" },
+};
+
+export default function ImageToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="Image"
+      badgeLabel="Image Tools"
+      heading="All Image Tools"
+      description="Fast browser-based tools to optimize and edit images without uploading your files."
+      accentClassName="border-sky-500/30 bg-sky-500/10 text-sky-400"
+    />
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,7 +78,7 @@ const jsonLd = [
         "description": "Free online tools for image, PDF, text, and developer work. Privacy-first, no uploads required.",
         "foundingDate": "2024",
         "sameAs": [
-          "https://github.com/utilbyte"
+          "https://github.com/KryssNa/utilbyte"
         ],
         "contactPoint": {
           "@type": "ContactPoint",

--- a/src/app/pdf-tools/page.tsx
+++ b/src/app/pdf-tools/page.tsx
@@ -1,0 +1,21 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "PDF Tools - Merge, Split, Compress & Convert PDFs",
+  description:
+    "Free PDF tools to merge, split, compress, edit, rotate, and convert PDF files in your browser with privacy-first processing.",
+  alternates: { canonical: "/pdf-tools" },
+};
+
+export default function PdfToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="PDF"
+      badgeLabel="PDF Tools"
+      heading="All PDF Tools"
+      description="Edit and optimize PDFs directly in your browser with no account required."
+      accentClassName="border-rose-500/30 bg-rose-500/10 text-rose-400"
+    />
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,14 +1,14 @@
-import { MetadataRoute } from 'next';
+import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://utilbyte.app';
+  const baseUrl = (process.env.NEXT_PUBLIC_BASE_URL || "https://utilbyte.app").replace(/\/$/, "");
 
   return {
     rules: [
       {
-        userAgent: '*',
-        allow: '/',
-        disallow: ['/api/', '/_next/', '/admin/', '/private/'],
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/admin/", "/private/"],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,322 +1,40 @@
-import { MetadataRoute } from 'next';
+import { toolCategories } from "@/components/layout/navbar/data";
+import { MetadataRoute } from "next";
+
+const staticRoutes: Array<{
+  path: string;
+  changeFrequency: "weekly" | "monthly" | "yearly";
+  priority: number;
+}> = [
+  { path: "", changeFrequency: "weekly", priority: 1 },
+  { path: "/about", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/contact", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/privacy", changeFrequency: "yearly", priority: 0.3 },
+  { path: "/terms", changeFrequency: "yearly", priority: 0.3 },
+  { path: "/dev-tools", changeFrequency: "monthly", priority: 0.85 },
+  { path: "/image-tools", changeFrequency: "monthly", priority: 0.75 },
+  { path: "/pdf-tools", changeFrequency: "monthly", priority: 0.75 },
+  { path: "/text-tools", changeFrequency: "monthly", priority: 0.75 },
+  { path: "/utility-tools", changeFrequency: "monthly", priority: 0.75 },
+  { path: "/video-tools", changeFrequency: "monthly", priority: 0.75 },
+];
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://utilbyte.app';
+  const baseUrl = (process.env.NEXT_PUBLIC_BASE_URL || "https://utilbyte.app").replace(/\/$/, "");
+  const now = new Date();
 
-  return [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 1,
-    },
-    // Legal Pages
-    {
-      url: `${baseUrl}/privacy`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/terms`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
-    // About & Contact
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    // Dev Tools
-    {
-      url: `${baseUrl}/dev-tools/base64`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/cron-parser`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/hash-generator`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/json-formatter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/jwt-decoder`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/markdown-renderer`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/regex-tester`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/url-encoder`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/uuid-generator`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/diff-checker`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/websocket-client`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/online-compiler`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/local-proxy`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/request-catcher`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/api-client`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/code-beautifier`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/dev-tools/sql-formatter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    // Image Tools
-    {
-      url: `${baseUrl}/image-tools/blur-image`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/compress-image`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/crop-image`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/format-converter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/ocr`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/remove-background`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/image-tools/resize-image`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    // PDF Tools
-    {
-      url: `${baseUrl}/pdf-tools/compress-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/image-to-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/merge-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/pdf-to-image`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/rotate-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/split-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/pdf-tools/edit-pdf`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    // Text Tools
-    {
-      url: `${baseUrl}/text-tools/case-converter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/text-tools/lorem-ipsum`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/text-tools/remove-duplicates`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/text-tools/text-formatter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/text-tools/word-counter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    // Utility Tools
-    {
-      url: `${baseUrl}/utility-tools/barcode`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/color-converter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/countdown`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/password-generator`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/qr-code`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/timestamp`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/utility-tools/unit-converter`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    // Video Tools
-    {
-      url: `${baseUrl}/video-tools/compress-video`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/video-tools/video-to-audio`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/video-tools/video-to-gif`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-  ];
+  const toolRoutes = toolCategories.flatMap((category) =>
+    category.tools.map((tool) => ({
+      path: tool.href,
+      changeFrequency: "monthly" as const,
+      priority: category.title === "Dev" ? 0.85 : 0.8,
+    }))
+  );
+
+  return [...staticRoutes, ...toolRoutes].map((route) => ({
+    url: `${baseUrl}${route.path}`,
+    lastModified: now,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
 }

--- a/src/app/text-tools/page.tsx
+++ b/src/app/text-tools/page.tsx
@@ -1,0 +1,21 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Text Tools - Count, Format, Convert & Clean Text",
+  description:
+    "Free text tools for case conversion, word counting, text formatting, lorem ipsum generation, and duplicate removal.",
+  alternates: { canonical: "/text-tools" },
+};
+
+export default function TextToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="Text"
+      badgeLabel="Text Tools"
+      heading="All Text Tools"
+      description="Simple and fast tools to process text for writing, content editing, and productivity."
+      accentClassName="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+    />
+  );
+}

--- a/src/app/utility-tools/page.tsx
+++ b/src/app/utility-tools/page.tsx
@@ -1,0 +1,21 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Utility Tools - QR, Barcode, Password, Time & Conversion",
+  description:
+    "Free utility tools including QR code generator, barcode creator, password generator, timestamp converter, countdown timer, and more.",
+  alternates: { canonical: "/utility-tools" },
+};
+
+export default function UtilityToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="Utility"
+      badgeLabel="Utility Tools"
+      heading="All Utility Tools"
+      description="Everyday utility tools for quick conversions, security, and sharing workflows."
+      accentClassName="border-cyan-500/30 bg-cyan-500/10 text-cyan-400"
+    />
+  );
+}

--- a/src/app/video-tools/page.tsx
+++ b/src/app/video-tools/page.tsx
@@ -1,0 +1,21 @@
+import ToolCategoryPage from "@/components/shared/ToolCategoryPage";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Video Tools - Compress Video, Extract Audio, Convert to GIF",
+  description:
+    "Free browser-based video tools to compress videos, extract audio, and convert clips to GIFs with privacy-first local processing.",
+  alternates: { canonical: "/video-tools" },
+};
+
+export default function VideoToolsCategoryPage() {
+  return (
+    <ToolCategoryPage
+      categoryTitle="Video"
+      badgeLabel="Video Tools"
+      heading="All Video Tools"
+      description="Convert and optimize video files directly in your browser."
+      accentClassName="border-orange-500/30 bg-orange-500/10 text-orange-400"
+    />
+  );
+}

--- a/src/components/layout/navbar/data.ts
+++ b/src/components/layout/navbar/data.ts
@@ -78,7 +78,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "Image",
     icon: Image,
-    href: "/#image-tools",
+    href: "/image-tools",
     color: "text-sky-600 dark:text-sky-400",
     bgColor: "bg-sky-500/10",
     hoverBg: "hover:bg-sky-500/10",
@@ -95,7 +95,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "PDF",
     icon: FileText,
-    href: "/#pdf-tools",
+    href: "/pdf-tools",
     color: "text-rose-600 dark:text-rose-400",
     bgColor: "bg-rose-500/10",
     hoverBg: "hover:bg-rose-500/10",
@@ -112,7 +112,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "Text",
     icon: Type,
-    href: "/#text-tools",
+    href: "/text-tools",
     color: "text-emerald-600 dark:text-emerald-400",
     bgColor: "bg-emerald-500/10",
     hoverBg: "hover:bg-emerald-500/10",
@@ -127,7 +127,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "Dev",
     icon: Code2,
-    href: "/#dev-tools",
+    href: "/dev-tools",
     color: "text-amber-600 dark:text-amber-400",
     bgColor: "bg-amber-500/10",
     hoverBg: "hover:bg-amber-500/10",
@@ -154,7 +154,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "Video",
     icon: Video,
-    href: "/#video-tools",
+    href: "/video-tools",
     color: "text-orange-600 dark:text-orange-400",
     bgColor: "bg-orange-500/10",
     hoverBg: "hover:bg-orange-500/10",
@@ -167,7 +167,7 @@ export const toolCategories: ToolCategory[] = [
   {
     title: "Utility",
     icon: Wrench,
-    href: "/#utility-tools",
+    href: "/utility-tools",
     color: "text-cyan-600 dark:text-cyan-400",
     bgColor: "bg-cyan-500/10",
     hoverBg: "hover:bg-cyan-500/10",

--- a/src/components/shared/ToolCategoryPage.tsx
+++ b/src/components/shared/ToolCategoryPage.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { toolCategories } from "@/components/layout/navbar/data";
+
+type CategoryTitle = "Image" | "PDF" | "Text" | "Dev" | "Video" | "Utility";
+
+interface ToolCategoryPageProps {
+  categoryTitle: CategoryTitle;
+  badgeLabel: string;
+  heading: string;
+  description: string;
+  accentClassName: string;
+}
+
+export default function ToolCategoryPage({
+  categoryTitle,
+  badgeLabel,
+  heading,
+  description,
+  accentClassName,
+}: ToolCategoryPageProps) {
+  const category = toolCategories.find((item) => item.title === categoryTitle);
+  const tools = category?.tools ?? [];
+
+  return (
+    <section className="container mx-auto px-4 py-10 md:py-16">
+      <header className="mb-8 space-y-3">
+        <div className={`inline-flex items-center rounded-full border px-3 py-1 text-sm ${accentClassName}`}>
+          {badgeLabel}
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{heading}</h1>
+        <p className="max-w-2xl text-muted-foreground">{description}</p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {tools.map((tool) => (
+          <Link
+            key={tool.href}
+            href={tool.href}
+            className="group rounded-xl border border-border bg-card p-5 transition hover:shadow-sm"
+          >
+            <h2 className="text-lg font-semibold">{tool.title}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{tool.desc}</p>
+            <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary group-hover:gap-2">
+              Open tool <ArrowRight className="h-4 w-4" />
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide dedicated category landing pages to group and browse related tools (Image, PDF, Text, Dev, Utility, Video).
- Centralize category UI with a reusable component to reduce duplication and ensure consistent layout.
- Generate an up-to-date sitemap programmatically from the canonical tool list and ensure robots sitemap URL is stable.

### Description
- Added new category pages under `src/app/*-tools/page.tsx` for Dev, Image, PDF, Text, Utility, and Video that use a shared `ToolCategoryPage` component.
- Introduced `src/components/shared/ToolCategoryPage.tsx` to render category metadata and a grid of tools based on `toolCategories`.
- Updated `src/components/layout/navbar/data.ts` to use canonical category routes (replaced hash links with `/image-tools`, `/pdf-tools`, etc.) and kept the master `toolCategories` list used by the sitemap and component.
- Refactored `src/app/sitemap.ts` to build sitemap entries from `toolCategories` plus a `staticRoutes` list, and normalized the base URL; also trimmed homepage organization `sameAs` GitHub URL in `src/app/page.tsx` and cleaned robots URL handling in `src/app/robots.ts`.

### Testing
- Ran TypeScript checks and project build (`npm run type-check` and `npm run build`) and the build completed successfully.
- Linted and type-checked the modified files with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3c8a54d083229fc3ab6d928ed211)